### PR TITLE
v0.0.9 [CIRC-8780]

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: true
-          go-version: 1.16.x
+          go-version: 1.17.x
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.48
           skip-go-installation: true
           args: --timeout=5m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.0.9
+
+* chore: add RefreshCheckBundle tests
+* feet: add `RefreshCheckBundle` method
+* chore: add UpdateCheckTags tests
+* feat: add `UpdateCheckTags` method
+* fix: ensure the trap check has been initialized
+* feat(deps): bump go-apiclient from 0.7.15 to 0.7.18
+* feat(deps): bump go-retryablehttp from 0.7.0 to 0.7.1
+* fix(lint): ioutil deprecation
+* chore: update to go1.17
+
 # v0.0.8
 
 * add: reset flag and handle rest in setBrokerTLSConfig

--- a/api.go
+++ b/api.go
@@ -20,4 +20,5 @@ type API interface {
 	FetchCheckBundle(cid apiclient.CIDType) (*apiclient.CheckBundle, error)
 	CreateCheckBundle(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error)
 	SearchCheckBundles(searchCriteria *apiclient.SearchQueryType, filterCriteria *apiclient.SearchFilterType) (*[]apiclient.CheckBundle, error)
+	UpdateCheckBundle(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error)
 }

--- a/api_moq_test.go
+++ b/api_moq_test.go
@@ -39,6 +39,9 @@ var _ API = &APIMock{}
 // 			SearchCheckBundlesFunc: func(searchCriteria *apiclient.SearchQueryType, filterCriteria *apiclient.SearchFilterType) (*[]apiclient.CheckBundle, error) {
 // 				panic("mock out the SearchCheckBundles method")
 // 			},
+// 			UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+// 				panic("mock out the UpdateCheckBundle method")
+// 			},
 // 		}
 //
 // 		// use mockedAPI in code that requires API
@@ -66,6 +69,9 @@ type APIMock struct {
 
 	// SearchCheckBundlesFunc mocks the SearchCheckBundles method.
 	SearchCheckBundlesFunc func(searchCriteria *apiclient.SearchQueryType, filterCriteria *apiclient.SearchFilterType) (*[]apiclient.CheckBundle, error)
+
+	// UpdateCheckBundleFunc mocks the UpdateCheckBundle method.
+	UpdateCheckBundleFunc func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -106,6 +112,11 @@ type APIMock struct {
 			// FilterCriteria is the filterCriteria argument value.
 			FilterCriteria *apiclient.SearchFilterType
 		}
+		// UpdateCheckBundle holds details about calls to the UpdateCheckBundle method.
+		UpdateCheckBundle []struct {
+			// Cfg is the cfg argument value.
+			Cfg *apiclient.CheckBundle
+		}
 	}
 	lockCreateCheckBundle  sync.RWMutex
 	lockFetchBroker        sync.RWMutex
@@ -114,6 +125,7 @@ type APIMock struct {
 	lockGet                sync.RWMutex
 	lockSearchBrokers      sync.RWMutex
 	lockSearchCheckBundles sync.RWMutex
+	lockUpdateCheckBundle  sync.RWMutex
 }
 
 // CreateCheckBundle calls CreateCheckBundleFunc.
@@ -333,5 +345,36 @@ func (mock *APIMock) SearchCheckBundlesCalls() []struct {
 	mock.lockSearchCheckBundles.RLock()
 	calls = mock.calls.SearchCheckBundles
 	mock.lockSearchCheckBundles.RUnlock()
+	return calls
+}
+
+// UpdateCheckBundle calls UpdateCheckBundleFunc.
+func (mock *APIMock) UpdateCheckBundle(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+	if mock.UpdateCheckBundleFunc == nil {
+		panic("APIMock.UpdateCheckBundleFunc: method is nil but API.UpdateCheckBundle was just called")
+	}
+	callInfo := struct {
+		Cfg *apiclient.CheckBundle
+	}{
+		Cfg: cfg,
+	}
+	mock.lockUpdateCheckBundle.Lock()
+	mock.calls.UpdateCheckBundle = append(mock.calls.UpdateCheckBundle, callInfo)
+	mock.lockUpdateCheckBundle.Unlock()
+	return mock.UpdateCheckBundleFunc(cfg)
+}
+
+// UpdateCheckBundleCalls gets all the calls that were made to UpdateCheckBundle.
+// Check the length with:
+//     len(mockedAPI.UpdateCheckBundleCalls())
+func (mock *APIMock) UpdateCheckBundleCalls() []struct {
+	Cfg *apiclient.CheckBundle
+} {
+	var calls []struct {
+		Cfg *apiclient.CheckBundle
+	}
+	mock.lockUpdateCheckBundle.RLock()
+	calls = mock.calls.UpdateCheckBundle
+	mock.lockUpdateCheckBundle.RUnlock()
 	return calls
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -7,7 +7,7 @@ package trapcheck
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +21,7 @@ import (
 func TestTrapCheck_brokerSupportsCheckType(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -83,7 +83,7 @@ func TestTrapCheck_brokerSupportsCheckType(t *testing.T) {
 func TestTrapCheck_getBrokerCNList(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -208,7 +208,7 @@ func TestTrapCheck_getBrokerCNList(t *testing.T) {
 func TestTrapCheck_isValidBroker(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -334,7 +334,7 @@ func TestTrapCheck_isValidBroker(t *testing.T) {
 func TestTrapCheck_getBroker(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 

--- a/check.go
+++ b/check.go
@@ -129,6 +129,10 @@ func (tc *TrapCheck) createCheckBundle(cfg *apiclient.CheckBundle) error {
 	if cfg == nil {
 		return fmt.Errorf("invalid check bundle config (nil)")
 	}
+	if cfg.Type == "" {
+		return fmt.Errorf("invalid check bundle config (no check type)")
+	}
+
 	// add broker here, no reason to do it in applying defaults as that's
 	// done every time, even when a check could be found (so no point "selecting"
 	// a broker to create a check, when a check already exists)
@@ -139,6 +143,7 @@ func (tc *TrapCheck) createCheckBundle(cfg *apiclient.CheckBundle) error {
 		}
 		cfg.Brokers = []string{tc.broker.CID}
 	}
+
 	bundle, err := tc.client.CreateCheckBundle(cfg)
 	if err != nil {
 		return fmt.Errorf("create check bundle: %w", err)

--- a/check_tags.go
+++ b/check_tags.go
@@ -1,0 +1,56 @@
+package trapcheck
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/circonus-labs/go-apiclient"
+)
+
+func (tc *TrapCheck) UpdateCheckTags(ctx context.Context, tags []string) (*apiclient.CheckBundle, error) {
+	if len(tags) == 0 {
+		return nil, nil
+	}
+
+	update := false
+	for _, tag := range tags {
+		found := false
+		tagParts := strings.SplitN(tag, ":", 2)
+		for j, ctag := range tc.checkBundle.Tags {
+			if tag == ctag {
+				found = true
+				break
+			}
+
+			ctagParts := strings.SplitN(ctag, ":", 2)
+			if len(tagParts) == len(ctagParts) {
+				if tagParts[0] == ctagParts[0] {
+					if tagParts[1] != ctagParts[1] {
+						tc.Log.Warnf("modifying tag: new: %v old: %v", tagParts, ctagParts)
+						tc.checkBundle.Tags[j] = tag
+						update = true // but force update since we're modifying a tag
+						found = true
+						break
+					}
+				}
+
+			}
+		}
+		if !found {
+			tc.Log.Warnf("adding missing tag: %s curr: %v", tag, tc.checkBundle.Tags)
+			tc.checkBundle.Tags = append(tc.checkBundle.Tags, tag)
+			update = true
+		}
+	}
+
+	if update {
+		b, err := tc.client.UpdateCheckBundle(tc.checkBundle)
+		if err != nil {
+			return nil, fmt.Errorf("api updating check bundle tags: %w", err)
+		}
+		return b, nil
+	}
+
+	return nil, nil
+}

--- a/check_tags.go
+++ b/check_tags.go
@@ -9,12 +9,18 @@ import (
 )
 
 func (tc *TrapCheck) UpdateCheckTags(ctx context.Context, tags []string) (*apiclient.CheckBundle, error) {
+	if tc.checkBundle == nil {
+		return nil, fmt.Errorf("invalid state, check bundle is nil")
+	}
 	if len(tags) == 0 {
 		return nil, nil
 	}
 
 	update := false
 	for _, tag := range tags {
+		if tag == "" {
+			continue
+		}
 		found := false
 		tagParts := strings.SplitN(tag, ":", 2)
 		for j, ctag := range tc.checkBundle.Tags {

--- a/check_tags_test.go
+++ b/check_tags_test.go
@@ -1,0 +1,132 @@
+package trapcheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/circonus-labs/go-apiclient"
+)
+
+func TestTrapCheck_UpdateCheckTags(t *testing.T) {
+	tc := &TrapCheck{}
+	tc.Log = &LogWrapper{
+		Log:   log.New(io.Discard, "", log.LstdFlags),
+		Debug: false,
+	}
+
+	tests := []struct {
+		client  API
+		bundle  *apiclient.CheckBundle
+		want    *apiclient.CheckBundle
+		name    string
+		newTags []string
+		wantErr bool
+	}{
+		{
+			name: "new tag",
+			bundle: &apiclient.CheckBundle{
+				Tags: []string{"foo"},
+			},
+			newTags: []string{"bar"},
+			want: &apiclient.CheckBundle{
+				Tags: []string{"foo", "bar"},
+			},
+			wantErr: false,
+			client: &APIMock{
+				UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+					return cfg, nil
+				},
+			},
+		},
+		{
+			name: "new tag, ignore blank",
+			bundle: &apiclient.CheckBundle{
+				Tags: []string{"foo"},
+			},
+			newTags: []string{"bar", ""},
+			want: &apiclient.CheckBundle{
+				Tags: []string{"foo", "bar"},
+			},
+			wantErr: false,
+			client: &APIMock{
+				UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+					return cfg, nil
+				},
+			},
+		},
+		{
+			name: "modify tag",
+			bundle: &apiclient.CheckBundle{
+				Tags: []string{"foo:bar"},
+			},
+			newTags: []string{"foo:baz"},
+			want: &apiclient.CheckBundle{
+				Tags: []string{"foo:baz"},
+			},
+			wantErr: false,
+			client: &APIMock{
+				UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+					return cfg, nil
+				},
+			},
+		},
+		{
+			name: "no change",
+			bundle: &apiclient.CheckBundle{
+				Tags: []string{"foo"},
+			},
+			newTags: []string{"foo"},
+			want:    nil,
+			wantErr: false,
+			client: &APIMock{
+				UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+					return cfg, nil
+				},
+			},
+		},
+		{
+			name:    "invalid (nil check bundle)",
+			bundle:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "no tags",
+			bundle:  &apiclient.CheckBundle{},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "api error",
+			bundle:  &apiclient.CheckBundle{Tags: []string{"foo"}},
+			newTags: []string{"bar"},
+			want:    nil,
+			wantErr: true,
+			client: &APIMock{
+				UpdateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
+					return nil, fmt.Errorf("api error 500")
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			tc.client = tt.client
+			tc.checkBundle = tt.bundle
+
+			got, err := tc.UpdateCheckTags(context.Background(), tt.newTags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TrapCheck.UpdateCheckTags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TrapCheck.UpdateCheckTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/check_test.go
+++ b/check_test.go
@@ -150,6 +150,37 @@ func TestTrapCheck_fetchCheckBundle(t *testing.T) {
 			},
 		},
 		{
+			name:        "invalid, check not active",
+			checkConfig: &apiclient.CheckBundle{CID: "/check_bundle/123"},
+			wantErr:     true,
+			client: &APIMock{
+				FetchCheckBundleFunc: func(cid apiclient.CIDType) (*apiclient.CheckBundle, error) {
+					return &apiclient.CheckBundle{
+						CID:     "/check_bundle/123",
+						Config:  apiclient.CheckBundleConfig{"submission_url": "http://127.0.0.1"},
+						Brokers: []string{"/broker/123"},
+						Type:    "httptrap:cua:host:linux",
+						Status:  "invalid",
+					}, nil
+				},
+				FetchBrokerFunc: func(cid apiclient.CIDType) (*apiclient.Broker, error) {
+					return &apiclient.Broker{
+						CID:  "/broker/123",
+						Name: "foo",
+						Type: circonusType,
+						Details: []apiclient.BrokerDetail{
+							{
+								Status:  statusActive,
+								Modules: []string{"httptrap"},
+								IP:      &brokerIP,
+								Port:    &brokerPort,
+							},
+						},
+					}, nil
+				},
+			},
+		},
+		{
 			name:        "valid",
 			checkConfig: &apiclient.CheckBundle{CID: "/check_bundle/123"},
 			wantErr:     false,
@@ -160,6 +191,7 @@ func TestTrapCheck_fetchCheckBundle(t *testing.T) {
 						Config:  apiclient.CheckBundleConfig{"submission_url": "http://127.0.0.1"},
 						Brokers: []string{"/broker/123"},
 						Type:    "httptrap:cua:host:linux",
+						Status:  statusActive,
 					}, nil
 				},
 				FetchBrokerFunc: func(cid apiclient.CIDType) (*apiclient.Broker, error) {
@@ -199,6 +231,22 @@ func TestTrapCheck_createCheckBundle(t *testing.T) {
 		Debug: false,
 	}
 
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "beep boop")
+	}))
+	defer ts.Close()
+
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("creating test broker: %s", err)
+	}
+	brokerIP := tsURL.Hostname()
+	bp, err := strconv.Atoi(tsURL.Port())
+	if err != nil {
+		t.Fatalf("parsing test broker port: %s", err)
+	}
+	brokerPort := uint16(bp)
+
 	tests := []struct {
 		client  API
 		cfg     *apiclient.CheckBundle
@@ -216,6 +264,24 @@ func TestTrapCheck_createCheckBundle(t *testing.T) {
 				CreateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
 					return nil, fmt.Errorf("API 500 - failure")
 				},
+				FetchBrokersFunc: func() (*[]apiclient.Broker, error) {
+					return &[]apiclient.Broker{
+						{
+							CID:  "/broker/123",
+							Name: "foo",
+							Type: circonusType,
+							Details: []apiclient.BrokerDetail{
+								{
+									CN:      "testbroker.example.com",
+									Status:  statusActive,
+									Modules: []string{"httptrap"},
+									IP:      &brokerIP,
+									Port:    &brokerPort,
+								},
+							},
+						},
+					}, nil
+				},
 			},
 			wantErr: true,
 		},
@@ -226,6 +292,24 @@ func TestTrapCheck_createCheckBundle(t *testing.T) {
 				CreateCheckBundleFunc: func(cfg *apiclient.CheckBundle) (*apiclient.CheckBundle, error) {
 					return &apiclient.CheckBundle{CID: "/check_bundle/123"}, nil
 				},
+				FetchBrokersFunc: func() (*[]apiclient.Broker, error) {
+					return &[]apiclient.Broker{
+						{
+							CID:  "/broker/123",
+							Name: "foo",
+							Type: circonusType,
+							Details: []apiclient.BrokerDetail{
+								{
+									CN:      "testbroker.example.com",
+									Status:  statusActive,
+									Modules: []string{"httptrap"},
+									IP:      &brokerIP,
+									Port:    &brokerPort,
+								},
+							},
+						},
+					}, nil
+				},
 			},
 			wantErr: false,
 		},
@@ -233,6 +317,11 @@ func TestTrapCheck_createCheckBundle(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "valid" {
+				if err := tc.applyCheckBundleDefaults(tt.cfg); err != nil {
+					t.Fatalf("applying defaults: %s", err)
+				}
+			}
 			tc.client = tt.client
 			if err := tc.createCheckBundle(tt.cfg); (err != nil) != tt.wantErr {
 				t.Errorf("TrapCheck.createCheckBundle() error = %v, wantErr %v", err, tt.wantErr)
@@ -382,6 +471,22 @@ func TestTrapCheck_initCheckBundle(t *testing.T) {
 		Debug: false,
 	}
 
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "beep boop")
+	}))
+	defer ts.Close()
+
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("creating test broker: %s", err)
+	}
+	brokerIP := tsURL.Hostname()
+	bp, err := strconv.Atoi(tsURL.Port())
+	if err != nil {
+		t.Fatalf("parsing test broker port: %s", err)
+	}
+	brokerPort := uint16(bp)
+
 	tests := []struct {
 		client          API
 		cfg             *apiclient.CheckBundle
@@ -425,6 +530,24 @@ func TestTrapCheck_initCheckBundle(t *testing.T) {
 				SearchCheckBundlesFunc: func(searchCriteria *apiclient.SearchQueryType, filterCriteria *apiclient.SearchFilterType) (*[]apiclient.CheckBundle, error) {
 					return &[]apiclient.CheckBundle{}, nil
 				},
+				FetchBrokersFunc: func() (*[]apiclient.Broker, error) {
+					return &[]apiclient.Broker{
+						{
+							CID:  "/broker/123",
+							Name: "foo",
+							Type: circonusType,
+							Details: []apiclient.BrokerDetail{
+								{
+									CN:      "testbroker.example.com",
+									Status:  statusActive,
+									Modules: []string{"httptrap"},
+									IP:      &brokerIP,
+									Port:    &brokerPort,
+								},
+							},
+						},
+					}, nil
+				},
 			},
 		},
 		{
@@ -438,6 +561,24 @@ func TestTrapCheck_initCheckBundle(t *testing.T) {
 				},
 				SearchCheckBundlesFunc: func(searchCriteria *apiclient.SearchQueryType, filterCriteria *apiclient.SearchFilterType) (*[]apiclient.CheckBundle, error) {
 					return &[]apiclient.CheckBundle{}, nil
+				},
+				FetchBrokersFunc: func() (*[]apiclient.Broker, error) {
+					return &[]apiclient.Broker{
+						{
+							CID:  "/broker/123",
+							Name: "foo",
+							Type: circonusType,
+							Details: []apiclient.BrokerDetail{
+								{
+									CN:      "testbroker.example.com",
+									Status:  statusActive,
+									Modules: []string{"httptrap"},
+									IP:      &brokerIP,
+									Port:    &brokerPort,
+								},
+							},
+						},
+					}, nil
 				},
 			},
 		},
@@ -491,6 +632,7 @@ func TestTrapCheck_initializeCheck(t *testing.T) {
 				CID:     "/check_bundle/123",
 				Brokers: []string{"/broker/123"},
 				Type:    "httptrap",
+				Status:  statusActive,
 			},
 			client: &APIMock{
 				FetchCheckBundleFunc: func(cid apiclient.CIDType) (*apiclient.CheckBundle, error) {
@@ -505,6 +647,7 @@ func TestTrapCheck_initializeCheck(t *testing.T) {
 				CID:     "/check_bundle/123",
 				Brokers: []string{"/broker/123"},
 				Type:    "httptrap",
+				Status:  statusActive,
 			},
 			client: &APIMock{
 				FetchCheckBundleFunc: func(cid apiclient.CIDType) (*apiclient.CheckBundle, error) {
@@ -526,6 +669,7 @@ func TestTrapCheck_initializeCheck(t *testing.T) {
 						Brokers: []string{"/broker/123"},
 						Type:    "httptrap",
 						Config:  apiclient.CheckBundleConfig{"submission_url": fmt.Sprintf("http://%s:%d", brokerIP, brokerPort)},
+						Status:  statusActive,
 					}, nil
 				},
 				FetchBrokerFunc: func(cid apiclient.CIDType) (*apiclient.Broker, error) {
@@ -557,6 +701,7 @@ func TestTrapCheck_initializeCheck(t *testing.T) {
 							Type:    "httptrap:foo:bar",
 							Brokers: []string{"/broker/123"},
 							Config:  apiclient.CheckBundleConfig{"submission_url": fmt.Sprintf("http://%s:%d", brokerIP, brokerPort)},
+							Status:  statusActive,
 						},
 					}, nil
 				},
@@ -593,6 +738,7 @@ func TestTrapCheck_initializeCheck(t *testing.T) {
 						Type:    "httptrap:foo:bar",
 						Brokers: []string{"/broker/123"},
 						Config:  apiclient.CheckBundleConfig{"submission_url": fmt.Sprintf("http://%s:%d", brokerIP, brokerPort)},
+						Status:  statusActive,
 					}, nil
 				},
 				FetchBrokersFunc: func() (*[]apiclient.Broker, error) {

--- a/check_test.go
+++ b/check_test.go
@@ -7,7 +7,7 @@ package trapcheck
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +21,7 @@ import (
 func TestTrapCheck_applyCheckBundleDefaults(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -86,7 +86,7 @@ func TestTrapCheck_applyCheckBundleDefaults(t *testing.T) {
 func TestTrapCheck_fetchCheckBundle(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -195,7 +195,7 @@ func TestTrapCheck_fetchCheckBundle(t *testing.T) {
 func TestTrapCheck_createCheckBundle(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -244,7 +244,7 @@ func TestTrapCheck_createCheckBundle(t *testing.T) {
 func TestTrapCheck_findCheckBundle(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -378,7 +378,7 @@ func TestTrapCheck_findCheckBundle(t *testing.T) {
 func TestTrapCheck_initCheckBundle(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -457,7 +457,7 @@ func TestTrapCheck_initCheckBundle(t *testing.T) {
 func TestTrapCheck_initializeCheck(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/circonus-labs/go-trapcheck
 go 1.17
 
 require (
-	github.com/circonus-labs/go-apiclient v0.7.15
+	github.com/circonus-labs/go-apiclient v0.7.18
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/circonus-labs/go-apiclient v0.7.15
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-retryablehttp v0.7.0
+	github.com/hashicorp/go-retryablehttp v0.7.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
 module github.com/circonus-labs/go-trapcheck
 
-go 1.16
+go 1.17
 
 require (
 	github.com/circonus-labs/go-apiclient v0.7.15
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.0
+)
+
+require (
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/circonus-labs/go-apiclient v0.7.15 h1:r9sUdc+EDM0tL6Z6u03dac8fxYvlz1kPhxlNwkoIoqM=
-github.com/circonus-labs/go-apiclient v0.7.15/go.mod h1:RFgkvdYEkimzgu3V2vVYlS1bitjOz1SF6uw109ieNeY=
+github.com/circonus-labs/go-apiclient v0.7.18 h1:OrRHUwoFroEUN+3KylQkdQOaTN1s3SCFh9E6D7Eb9PQ=
+github.com/circonus-labs/go-apiclient v0.7.18/go.mod h1:NCu3kJ282ZGzr7vxzFH/S28y1nW9DZ37f8L7veDENFc=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -7,7 +7,6 @@ github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVo
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtng
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
-github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
-github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/submit.go
+++ b/submit.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -237,7 +236,7 @@ func (tc *TrapCheck) submit(ctx context.Context, metrics bytes.Buffer) (*TrapRes
 		return nil, false, fmt.Errorf("making request: %w", err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, false, fmt.Errorf("reading response body: %w", err)
 	}

--- a/tls_test.go
+++ b/tls_test.go
@@ -8,7 +8,7 @@ package trapcheck
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"reflect"
 	"testing"
@@ -19,7 +19,7 @@ import (
 func TestTrapCheck_fetchCert(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -89,7 +89,7 @@ func TestTrapCheck_fetchCert(t *testing.T) {
 func TestTrapCheck_setBrokerTLSConfig(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 

--- a/tls_test.go
+++ b/tls_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/circonus-labs/go-apiclient"
+	"github.com/circonus-labs/go-apiclient/config"
 )
 
 func TestTrapCheck_fetchCert(t *testing.T) {
@@ -233,6 +234,9 @@ func TestTrapCheck_setBrokerTLSConfig(t *testing.T) {
 			tc.tlsConfig = tt.tlsConfig
 			tc.checkBundle = tt.checkBundle
 			tc.broker = tt.broker
+			if tc.checkBundle != nil {
+				tc.submissionURL = tt.checkBundle.Config[config.SubmissionURL]
+			}
 
 			if err := tc.setBrokerTLSConfig(); (err != nil) != tt.wantErr {
 				t.Errorf("TrapCheck.setBrokerTLSConfig() error = %v, wantErr %v", err, tt.wantErr)

--- a/trapcheck.go
+++ b/trapcheck.go
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 //
 
+//go:build go1.17
+
 package trapcheck
 
 import (
@@ -291,6 +293,18 @@ func (tc *TrapCheck) IsNewCheckBundle() bool {
 func (tc *TrapCheck) GetCheckBundle() (apiclient.CheckBundle, error) {
 	if tc.checkBundle == nil {
 		return apiclient.CheckBundle{}, fmt.Errorf("trap check not initialized/created")
+	}
+	return *tc.checkBundle, nil
+}
+
+// RefreshCheckBundle will pull down a fresh copy from the API.
+func (tc *TrapCheck) RefreshCheckBundle() (apiclient.CheckBundle, error) {
+	refreshed, refreshErr := tc.refreshCheck()
+	if refreshErr != nil {
+		return apiclient.CheckBundle{}, refreshErr
+	}
+	if !refreshed {
+		return apiclient.CheckBundle{}, fmt.Errorf("check bundle could not be refreshed - using custom submission URL %s", tc.custSubmissionURL)
 	}
 	return *tc.checkBundle, nil
 }

--- a/trapcheck.go
+++ b/trapcheck.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -104,7 +104,7 @@ func New(cfg *Config) (*TrapCheck, error) {
 		tc.Log = cfg.Logger
 	} else {
 		tc.Log = &LogWrapper{
-			Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+			Log:   log.New(io.Discard, "", log.LstdFlags),
 			Debug: false,
 		}
 	}
@@ -198,7 +198,7 @@ func NewFromCheckBundle(cfg *Config, bundle *apiclient.CheckBundle) (*TrapCheck,
 		tc.Log = cfg.Logger
 	} else {
 		tc.Log = &LogWrapper{
-			Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+			Log:   log.New(io.Discard, "", log.LstdFlags),
 			Debug: false,
 		}
 	}
@@ -357,7 +357,7 @@ func testTraceMetricsDir(dir string) error {
 		return fmt.Errorf("not a directory (%s)", dir)
 	}
 
-	tf, err := ioutil.TempFile(dir, "wtest")
+	tf, err := os.CreateTemp(dir, "wtest")
 	if err != nil {
 		return fmt.Errorf("unable to write to (%s): %w", dir, err)
 	}

--- a/trapcheck_test.go
+++ b/trapcheck_test.go
@@ -8,7 +8,7 @@ package trapcheck
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -96,7 +96,7 @@ func TestNew(t *testing.T) {
 func TestTrapCheck_GetBrokerTLSConfig(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 
@@ -138,7 +138,7 @@ func TestTrapCheck_GetBrokerTLSConfig(t *testing.T) {
 func TestTrapCheck_GetCheckBundle(t *testing.T) {
 	tc := &TrapCheck{}
 	tc.Log = &LogWrapper{
-		Log:   log.New(ioutil.Discard, "", log.LstdFlags),
+		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
 	}
 

--- a/trapcheck_test.go
+++ b/trapcheck_test.go
@@ -56,6 +56,7 @@ func TestNew(t *testing.T) {
 							Brokers: []string{"/broker/123"},
 							Type:    "httptrap",
 							Config:  apiclient.CheckBundleConfig{"submission_url": fmt.Sprintf("http://%s:%d", brokerIP, brokerPort)},
+							Status:  "active",
 						}, nil
 					},
 					FetchBrokerFunc: func(cid apiclient.CIDType) (*apiclient.Broker, error) {
@@ -94,7 +95,14 @@ func TestNew(t *testing.T) {
 }
 
 func TestTrapCheck_GetBrokerTLSConfig(t *testing.T) {
-	tc := &TrapCheck{}
+	tc := &TrapCheck{
+		checkBundle: &apiclient.CheckBundle{
+			Config: apiclient.CheckBundleConfig{
+				"submission_url": "https://127.0.0.1",
+			},
+		},
+		submissionURL: "https://127.0.0.1",
+	}
 	tc.Log = &LogWrapper{
 		Log:   log.New(io.Discard, "", log.LstdFlags),
 		Debug: false,
@@ -144,20 +152,20 @@ func TestTrapCheck_GetCheckBundle(t *testing.T) {
 
 	tests := []struct {
 		bundle  *apiclient.CheckBundle
-		want    *apiclient.CheckBundle
 		name    string
+		want    apiclient.CheckBundle
 		wantErr bool
 	}{
 		{
 			name:    "nil",
 			bundle:  nil,
-			want:    nil,
+			want:    apiclient.CheckBundle{},
 			wantErr: true,
 		},
 		{
 			name:    "valid",
 			bundle:  &apiclient.CheckBundle{CID: "/check_bundle/123"},
-			want:    &apiclient.CheckBundle{CID: "/check_bundle/123"},
+			want:    apiclient.CheckBundle{CID: "/check_bundle/123"},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
* chore: add RefreshCheckBundle tests
* feet: add `RefreshCheckBundle` method
* chore: add UpdateCheckTags tests
* feat: add `UpdateCheckTags` method
* fix: ensure the trap check has been initialized
* feat(deps): bump go-apiclient from 0.7.15 to 0.7.18
* feat(deps): bump go-retryablehttp from 0.7.0 to 0.7.1
* fix(lint): ioutil deprecation
* chore: update to go1.17
