### PR TITLE
v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # unreleased
 
+## v0.0.15
+
+* feat: add SubmissionTimeout option -- default 10s -- controls timing out requests to broker
+* build(deps): bump github.com/google/uuid from 1.4.0 to 1.5.0
+* build(deps): bump github.com/circonus-labs/go-apiclient from 0.7.23 to 0.7.24
 * fix: check tests to correctly initialize broker list
 * fix: GetBroker tests to work with broker_list
 

--- a/submit.go
+++ b/submit.go
@@ -38,8 +38,9 @@ type TrapResult struct {
 }
 
 const (
-	compressionThreshold = 1024
-	traceTSFormat        = "20060102_150405.000000000"
+	compressionThreshold     = 1024
+	traceTSFormat            = "20060102_150405.000000000"
+	defaultSubmissionTimeout = "10s"
 )
 
 func (tc *TrapCheck) submit(ctx context.Context, metrics bytes.Buffer) (*TrapResult, bool, error) {
@@ -74,7 +75,7 @@ func (tc *TrapCheck) submit(ctx context.Context, metrics bytes.Buffer) (*TrapRes
 				MaxIdleConns:        1,
 				MaxIdleConnsPerHost: 0,
 			},
-			Timeout: 60 * time.Second, // hard 60s timeout
+			Timeout: tc.submissionTimeout,
 		}
 	} else {
 		client = &http.Client{
@@ -90,7 +91,7 @@ func (tc *TrapCheck) submit(ctx context.Context, metrics bytes.Buffer) (*TrapRes
 				MaxIdleConns:        1,
 				MaxIdleConnsPerHost: 0,
 			},
-			Timeout: 60 * time.Second, // hard 60s timeout
+			Timeout: tc.submissionTimeout,
 		}
 	}
 


### PR DESCRIPTION
* feat: add SubmissionTimeout option -- default 10s -- controls timing out requests to broker
* build(deps): bump github.com/google/uuid from 1.4.0 to 1.5.0
* build(deps): bump github.com/circonus-labs/go-apiclient from 0.7.23 to 0.7.24
* fix: check tests to correctly initialize broker list
* fix: GetBroker tests to work with broker_list
